### PR TITLE
Allow to send sub {} as dbh

### DIFF
--- a/lib/ActiveRecord/Simple/Connect.pm
+++ b/lib/ActiveRecord/Simple/Connect.pm
@@ -69,7 +69,7 @@ sub dbh {
 		$self->{dbh} = $dbh;
 	}
 
-	return $self->{dbh};
+	return ref $self->{dbh} eq 'CODE' ? $self->{dbh}->() : $self->{dbh};
 }
 
 1;


### PR DESCRIPTION
According to README there is one way to keep database connection:
```
# or you can use a special function, like this:
sub dbhandler {
    unless ($dbh->ping) {
        $dbh->connect("...");
    }

    return $dbh;
}

ActiveRecord::Simple->dbh(&dbhandler);
```

But if we use some script as a daemon this method isn't acceptable because `unless ($dbh->ping) {` is called only once.

To check DB connection every time we need to modify the code:
```
# or you can use a special function, like this:
my $dbhandler = sub {
    $dbh = clone $dbh unless ping $dbh;
    return $dbh;
}

ActiveRecord::Simple->dbh($dbhandler);
```
and change ActiveRecord::Simple::Connect::dbh to allow to get dbh as a link to sub