### PR TITLE
Do not call AUTOLOAD on destroy

### DIFF
--- a/lib/ActiveRecord/Simple/Find.pm
+++ b/lib/ActiveRecord/Simple/Find.pm
@@ -623,6 +623,8 @@ sub _quote_sql_stmt {
     return 1;
 }
 
+sub DESTROY { }
+
 sub AUTOLOAD {
     my $call = $AUTOLOAD;
     my $self = shift;


### PR DESCRIPTION
On destroy object call DESTROY function which isn't defined in Find.pm so AUTOLOAD is called.
So every time object is destroyed croak is called.
```
(in cleanup) Can't call method `DESTROY` on class ActiveRecord::Simple::Find.
Perhaps you have forgotten to fetch your object? at ...
```