### PR TITLE
Use count with group_by

### DIFF
--- a/lib/ActiveRecord/Simple/Find.pm
+++ b/lib/ActiveRecord/Simple/Find.pm
@@ -84,34 +84,23 @@ sub new {
 }
 
 sub count {
-    my ($self_class, $class, @param) = @_;
-
-    my $self = bless {class => $class}, $self_class;
-    my $table_name = $class->_get_table_name;
-    my ($count, $sql, @bind);
-    if (scalar @param == 0) {
-        $self->{SQL} = qq/SELECT COUNT(*) FROM "$table_name"/;
+    my $inv = shift;
+    my $self = ref $inv ? $inv : $inv->new(@_);
+    $self->{prep_select_fields} = [ 'COUNT(*)' ];
+    if (@{ $self->{prep_group_by}||[] }) {
+        my $table_name = $self->{class}->_get_table_name;
+        push @{ $self->{prep_select_fields} }, map qq/"$table_name".$_/, @{ $self->{prep_group_by} };
+        my @group_by = @{ $self->{prep_group_by} };
+        s/"//g foreach @group_by;
+        my @results;
+        foreach my $item ($self->fetch) {
+            push my @line, (count => $item->{'COUNT(*)'}), map { $_ => $item->$_ } @group_by;
+            push @results, { @line };
+        }
+        return \@results;
+    } else {
+        return $self->fetch->{'COUNT(*)'};
     }
-    elsif (scalar @param == 1) {
-        my $params_hash = shift @param;
-        return unless ref $params_hash eq 'HASH';
-
-        my ($bind, $condition_pairs) = $self->parse_hash($params_hash);
-
-        @bind = @$bind;
-        my $wherestr = (scalar @$condition_pairs > 0 ) ? ' WHERE ' . join(q/ AND /, @$condition_pairs) : '';
-        $self->{SQL} = qq/SELECT COUNT(*) FROM "$table_name" $wherestr/;
-    }
-    elsif (scalar @param > 1) {
-        my $wherestr = shift @param;
-        @bind = @param;
-
-        $self->{SQL} = qq/SELECT COUNT(*) FROM "$table_name" WHERE $wherestr/;
-    }
-    $self->_quote_sql_stmt;
-    $count = $self->dbh->selectrow_array($self->{SQL}, undef, @bind);
-
-    return $count;
 }
 
 sub parse_hash {


### PR DESCRIPTION
Related to #92 issue
Now we can use `count()` method as following:
* `Model->count($criteria)` => returns a number
* `Model->find($criteria)->count` => returns a number, works like previous
* `Model->find($criteria)->group_by('field')->count` => returns [{field => "field", count => "count"},{...}]
So old API is sill here but added extra features